### PR TITLE
Add rules for php documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,9 @@ The body further specifies what changed and may include the motivation for the c
 ## PHP
 
 * follow [PSR-2](http://www.php-fig.org/psr/psr-2)
+* follow [PHPDoc](https://www.phpdoc.org/docs/latest/references/phpdoc/index.html)
+	* the `@param` tag is followed by two spaces, the argument type, two more spaces and the variable name
+	* use the short term for all primitives
 
 ## Ruby
 


### PR DESCRIPTION
A standard to follow for documenting php code inspired by the [Laravel way](https://laravel.com/docs/master/contributions#coding-style) of doing so. 
Additional rule to ensure the use of `int` and `bool` instead of `integer`and `boolean` (better match of type hinted parameters in php).